### PR TITLE
Format low numbers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,9 +70,9 @@ function privateKeyToChecksumAddress(privateKey) {
 
 function xeStringFromMicroXe(mxe) {
   const s = mxe.toString()
-  const fraction = s.substr(-6, 6)
+  const fraction = s.substr(-6, 6).padStart(6, '0')
   const whole = s.substr(0, s.length - 6)
-  return `${whole}.${fraction}`
+  return `${whole || 0}.${fraction}`
 }
 
 function toMicroXe(xe) {


### PR DESCRIPTION
Ensures 0 is formatted as 0.000000 and any value lower than 1 is correctly zero padded at the front